### PR TITLE
The old links were broken.

### DIFF
--- a/_episodes/02-Rstudio.md
+++ b/_episodes/02-Rstudio.md
@@ -65,10 +65,10 @@ This lesson is a combination of excellent lessons by others (see Credits) (thank
 
 I definitely recommend reading through the original lessons and using them as reference:   
 
-[Dr. Jenny Bryan's lectures from STAT545 at UBC](https://stat545-ubc.github.io/)
+[Dr. Jenny Bryan's lectures from STAT545 at R Studio Education](https://stat545.com/)
 
-- [R basics, workspace and working directory, RStudio projects](http://stat545-ubc.github.io/block002_hello-r-workspace-wd-project.html)
-- [Basic care and feeding of data in R](http://stat545-ubc.github.io/block006_care-feeding-data.html)
+- [R basics, workspace and working directory, RStudio projects](https://stat545.com/r-basics.html)
+- [Basic care and feeding of data in R](https://stat545.com/basic-data-care.html)
 
 RStudio has great resources about its IDE (IDE stands for integrated development environment): 
 


### PR DESCRIPTION
Hello everyone!

I updated the links to access the lessons from Dr. Jenny Bryan at their new location at R Studio Education.

Depending on the interest of the page/lesson creators, the links for the courses are also available in different (and new) links. Dr. Jenny Bryan's lectures from STAT545 at UBC (https://stat545.stat.ubc.ca)

Personally, I still use the links from (https://stat545.com) because she is citing that page all the time on her UCB website.

Have a nice day.

ps: I am sending this PR as a contribution for instructor training.

